### PR TITLE
usePortfolioIntro, usePortfolioModifyForm, PortfolioIntoroModfy 코드 구조 개선 

### DIFF
--- a/src/components/portfolio/introPart/PortfolioIntroContainer.tsx
+++ b/src/components/portfolio/introPart/PortfolioIntroContainer.tsx
@@ -3,7 +3,7 @@ import useIntroObserver from '@src/hooks/portfolio/intro/useIntroObserver';
 import { isModifyModeFromPortfolioIntro } from '@src/store/portfolio/modify';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import {  useRecoilValue } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 import IntroSkeleton from './IntroSkeleton';
 import PortfolioIntro from './PortfolioIntro';

--- a/src/components/portfolio/introPart/PortfolioIntroModify.tsx
+++ b/src/components/portfolio/introPart/PortfolioIntroModify.tsx
@@ -7,10 +7,12 @@ import styled from 'styled-components';
 import LoadingSpiner from '../common/LoadingSpiner';
 import ModifyComfirmAndCancleGroup from '../common/ModifyComfirmAndCancleGroup';
 import { Intro } from './commonIntroStyledComponent';
+import { usePortfolioInfo } from '@src/context/PortfolioInfoContext';
 
 export default function PortfolioIntroModify() {
+  const { portfolioId } = usePortfolioInfo();
   const { copiedPfIntro, onChangeInputEl, discriptionRef, handleSubmit } =
-    usePortfolioModifyForm();
+    usePortfolioModifyForm({ portfolioId });
   const titleRef = useRef<HTMLInputElement>(null);
   const hiddenFileBtnRef = useRef<HTMLInputElement>(null);
   const [isModifyMode, setIsModifyMode] = useRecoilState(

--- a/src/components/portfolio/introPart/PortfolioIntroModify.tsx
+++ b/src/components/portfolio/introPart/PortfolioIntroModify.tsx
@@ -1,24 +1,27 @@
 import usePortfolioModifyForm from '@src/hooks/portfolio/intro/usePortfolioModifyForm';
-import { introLoading } from '@src/store/portfolio/loading';
 import { isModifyModeFromPortfolioIntro } from '@src/store/portfolio/modify';
 import { useEffect, useRef } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 import LoadingSpiner from '../common/LoadingSpiner';
 import ModifyComfirmAndCancleGroup from '../common/ModifyComfirmAndCancleGroup';
 import { Intro } from './commonIntroStyledComponent';
-import { usePortfolioInfo } from '@src/context/PortfolioInfoContext';
+import usePortfolioIntro from '@src/hooks/portfolio/intro/usePortfolioIntro';
 
 export default function PortfolioIntroModify() {
-  const { portfolioId } = usePortfolioInfo();
+  const { pfIntro, isMutating, isFetching, updateIntro } = usePortfolioIntro();
   const { copiedPfIntro, onChangeInputEl, discriptionRef, handleSubmit } =
-    usePortfolioModifyForm({ portfolioId });
+    usePortfolioModifyForm({
+      originIntroData: pfIntro,
+      updateIntro,
+    });
+
   const titleRef = useRef<HTMLInputElement>(null);
   const hiddenFileBtnRef = useRef<HTMLInputElement>(null);
   const [isModifyMode, setIsModifyMode] = useRecoilState(
     isModifyModeFromPortfolioIntro
   );
-  const isLoading = useRecoilValue(introLoading);
+  const isLoading = isMutating || isFetching;
 
   useEffect(() => {
     //처음 수정모드로 들어 갔을때 타이틀에 포커스
@@ -71,17 +74,6 @@ export default function PortfolioIntroModify() {
     </ModifyIntro>
   );
 }
-
-// &:hover::before {
-//   content: '';
-//   width: 100%;
-//   height: 100%;
-//   position: absolute;
-//   top: 0;
-//   left: 0;
-//   z-index: -2;
-//   background-color: rgba(97, 97, 97, 0.053);
-// }
 
 const ModifyIntro = styled(Intro)`
   cursor: pointer;

--- a/src/context/PortfolioInfoContext.tsx
+++ b/src/context/PortfolioInfoContext.tsx
@@ -25,7 +25,6 @@ export default function PortfolioInfoContextProvider({
   const { portfolioId } = useParams() as ParamsType;
   const permissionModify = usePortfolioModifyPermission(portfolioId);
   const portfolioEmail = useGetNoteSender(portfolioId);
-
   const context = useMemo<ContextType>(() => {
     return { portfolioId, permissionModify, portfolioEmail };
   }, [portfolioId, permissionModify, portfolioEmail]);

--- a/src/hooks/portfolio/intro/usePortfolioIntro.ts
+++ b/src/hooks/portfolio/intro/usePortfolioIntro.ts
@@ -3,20 +3,23 @@ import service from '@src/service';
 import { PortfolioIntroType } from '@src/service/types/portfolio';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePortfolioInfo } from '@src/context/PortfolioInfoContext';
-import { introLoading } from '@src/store/portfolio/loading';
 import { isModifyModeFromPortfolioIntro } from '@src/store/portfolio/modify';
 import { queryKey } from '@src/react-query/queryKey';
 import { CopiedPfIntroType } from './usePortfolioModifyForm';
 
+export type UpdataIntroTData = PortfolioIntroType;
+export type UpdataIntroTVariables = Pick<
+  CopiedPfIntroType,
+  'backgroundImgFile' | 'title' | 'description' | 'portfolioId'
+>;
+
 export default function usePortfolioIntro() {
   const queryClient = useQueryClient();
-  const setIsLoading = useSetRecoilState(introLoading);
   const setModify = useSetRecoilState(isModifyModeFromPortfolioIntro);
   const { portfolioId } = usePortfolioInfo();
-  //todo 인트로 보내기 가져오기
 
   //1. suspense 사용시 onSuccess에 setState를 등록하면 업데이트가 안됨 이유는 unmount상태에서 변경했기때문
-  const { data } = useQuery(
+  const { data, isFetching } = useQuery(
     [queryKey.portfolioIntro, portfolioId],
     async () => await service.portfolio.getPortfolioIntro({ portfolioId }),
     {
@@ -25,12 +28,9 @@ export default function usePortfolioIntro() {
   );
 
   const updateIntro = useMutation<
-    PortfolioIntroType,
+    UpdataIntroTData,
     unknown,
-    Pick<
-      CopiedPfIntroType,
-      'backgroundImgFile' | 'title' | 'description' | 'portfolioId'
-    >,
+    UpdataIntroTVariables,
     unknown
   >(
     ({ title, description, backgroundImgFile, portfolioId }) => {
@@ -42,15 +42,13 @@ export default function usePortfolioIntro() {
       });
     },
     {
-      onMutate: () => {
-        setIsLoading(true);
-        //queryClient.invalidateQueries(['portfolioIntro', portfolioId]);
-      },
       onSuccess: (data) => {
-        queryClient.setQueryData([queryKey.portfolioIntro, portfolioId], data);
+        return queryClient.setQueryData(
+          [queryKey.portfolioIntro, portfolioId],
+          data
+        );
       },
       onSettled: () => {
-        setIsLoading(false);
         setModify(false);
       },
     }
@@ -59,5 +57,7 @@ export default function usePortfolioIntro() {
   return {
     pfIntro: data!,
     updateIntro: updateIntro.mutate,
+    isMutating: updateIntro.isLoading,
+    isFetching,
   };
 }

--- a/src/hooks/portfolio/intro/usePortfolioIntro.ts
+++ b/src/hooks/portfolio/intro/usePortfolioIntro.ts
@@ -3,35 +3,20 @@ import service from '@src/service';
 import { PortfolioIntroType } from '@src/service/types/portfolio';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePortfolioInfo } from '@src/context/PortfolioInfoContext';
-import { useEffect, useLayoutEffect, useState } from 'react';
 import { introLoading } from '@src/store/portfolio/loading';
 import { isModifyModeFromPortfolioIntro } from '@src/store/portfolio/modify';
 import { queryKey } from '@src/react-query/queryKey';
-
-type CopiedPfIntroType = Omit<
-  PortfolioIntroType,
-  'likeStatus' | 'likeCount'
-> & {
-  backgroundImgFile: File | null;
-};
+import { CopiedPfIntroType } from './usePortfolioModifyForm';
 
 export default function usePortfolioIntro() {
   const queryClient = useQueryClient();
-  const [copiedPfIntro, setCopiedPfIntro] = useState<CopiedPfIntroType>({
-    title: '',
-    description: '',
-    portfolioId: '',
-    jobName: '',
-    backgroundImg: '',
-    backgroundImgFile: null,
-  });
   const setIsLoading = useSetRecoilState(introLoading);
   const setModify = useSetRecoilState(isModifyModeFromPortfolioIntro);
   const { portfolioId } = usePortfolioInfo();
   //todo 인트로 보내기 가져오기
 
   //1. suspense 사용시 onSuccess에 setState를 등록하면 업데이트가 안됨 이유는 unmount상태에서 변경했기때문
-  const { data, isFetching } = useQuery(
+  const { data } = useQuery(
     [queryKey.portfolioIntro, portfolioId],
     async () => await service.portfolio.getPortfolioIntro({ portfolioId }),
     {
@@ -71,16 +56,8 @@ export default function usePortfolioIntro() {
     }
   );
 
-  //1에 대한 해결법으로 useLayoutEffect 걸어놓으면 됨 , 결과의 데이터를 기준으로
-  useLayoutEffect(() => {
-    data && setCopiedPfIntro((e) => ({ ...data, backgroundImgFile: null }));
-  }, [data]);
-
   return {
     pfIntro: data!,
     updateIntro: updateIntro.mutate,
-    copiedPfIntro,
-    setCopiedPfIntro,
-    isFetching,
   };
 }

--- a/src/hooks/portfolio/intro/usePortfolioModifyForm.ts
+++ b/src/hooks/portfolio/intro/usePortfolioModifyForm.ts
@@ -1,8 +1,31 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState, useLayoutEffect } from 'react';
 import usePortfolioIntro from './usePortfolioIntro';
+import { PortfolioIntroType } from '@src/service/types/portfolio';
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKey } from '@src/react-query/queryKey';
 
-export default function usePortfolioModifyForm() {
-  const { copiedPfIntro, setCopiedPfIntro, updateIntro } = usePortfolioIntro();
+export type CopiedPfIntroType = Omit<
+  PortfolioIntroType,
+  'likeStatus' | 'likeCount'
+> & {
+  backgroundImgFile: File | null;
+};
+
+type Props = {
+  portfolioId: string;
+};
+
+export default function usePortfolioModifyForm({ portfolioId }: Props) {
+  const queryClient = useQueryClient();
+  const { updateIntro } = usePortfolioIntro();
+  const [copiedPfIntro, setCopiedPfIntro] = useState<CopiedPfIntroType>({
+    title: '',
+    description: '',
+    portfolioId: '',
+    jobName: '',
+    backgroundImg: '',
+    backgroundImgFile: null,
+  });
   const discriptionRef = useRef<HTMLTextAreaElement>(null);
 
   const onChangeInputEl = (
@@ -50,6 +73,14 @@ export default function usePortfolioModifyForm() {
       discriptionRef.current.style.height = `${discriptionRef.current.scrollHeight}px`;
     }
   };
+
+  useLayoutEffect(() => {
+    const data = queryClient.getQueryData<PortfolioIntroType>([
+      queryKey.portfolioIntro,
+      portfolioId,
+    ]);
+    setCopiedPfIntro((e) => ({ ...data!, backgroundImgFile: null }));
+  }, []);
 
   // textarea 자동 크기 증가
   useEffect(() => {

--- a/src/hooks/portfolio/intro/usePortfolioModifyForm.ts
+++ b/src/hooks/portfolio/intro/usePortfolioModifyForm.ts
@@ -1,8 +1,7 @@
-import { useRef, useEffect, useState, useLayoutEffect } from 'react';
-import usePortfolioIntro from './usePortfolioIntro';
+import { useRef, useEffect, useState } from 'react';
+import { UpdataIntroTData, UpdataIntroTVariables } from './usePortfolioIntro';
 import { PortfolioIntroType } from '@src/service/types/portfolio';
-import { useQueryClient } from '@tanstack/react-query';
-import { queryKey } from '@src/react-query/queryKey';
+import { UseMutateFunction } from '@tanstack/react-query';
 
 export type CopiedPfIntroType = Omit<
   PortfolioIntroType,
@@ -12,18 +11,25 @@ export type CopiedPfIntroType = Omit<
 };
 
 type Props = {
-  portfolioId: string;
+  originIntroData: PortfolioIntroType;
+  updateIntro: UseMutateFunction<
+    UpdataIntroTData,
+    any,
+    UpdataIntroTVariables,
+    any
+  >;
 };
 
-export default function usePortfolioModifyForm({ portfolioId }: Props) {
-  const queryClient = useQueryClient();
-  const { updateIntro } = usePortfolioIntro();
+export default function usePortfolioModifyForm({
+  originIntroData,
+  updateIntro,
+}: Props) {
   const [copiedPfIntro, setCopiedPfIntro] = useState<CopiedPfIntroType>({
-    title: '',
-    description: '',
-    portfolioId: '',
-    jobName: '',
-    backgroundImg: '',
+    title: originIntroData.title,
+    description: originIntroData.description,
+    portfolioId: originIntroData.portfolioId,
+    jobName: originIntroData.jobName,
+    backgroundImg: originIntroData.backgroundImg,
     backgroundImgFile: null,
   });
   const discriptionRef = useRef<HTMLTextAreaElement>(null);
@@ -73,14 +79,6 @@ export default function usePortfolioModifyForm({ portfolioId }: Props) {
       discriptionRef.current.style.height = `${discriptionRef.current.scrollHeight}px`;
     }
   };
-
-  useLayoutEffect(() => {
-    const data = queryClient.getQueryData<PortfolioIntroType>([
-      queryKey.portfolioIntro,
-      portfolioId,
-    ]);
-    setCopiedPfIntro((e) => ({ ...data!, backgroundImgFile: null }));
-  }, []);
 
   // textarea 자동 크기 증가
   useEffect(() => {


### PR DESCRIPTION

- 기존 usePortfolioIntro <-> usePortfolioModifyForm 사이 강한 결합으로 코드가 복잡함

## 1. usePortfolioModifyForm는 form 맞게 코드 구조를 개선
- usePortfolioModifyForm는 update 함수를 호출만 하면 되는데 기존 코드는 호출을 어떻게 하고 결과를 어떻게 할지가 다 작성되어있었는데
- 그 내용은 usePortfolioIntro에 작성되고 usePortfolioModifyForm은 update함수를 호출만 하도록 변경

## 2. intro 전역 로딩 제거
- react-query의 내부 로딩 현황을 사용하여 로딩 전역 변수 제거

## 3. useLayoutEffect제거
- 기존 코드는 intro데이터를 내부 state에 등록하기위해 Effect를 사용하였는데 introdata를 인자로 받아오는 식으로 변경하여 제거